### PR TITLE
Refactor create_profile to use Stripe gem

### DIFF
--- a/app/decorators/models/spree/credit_card_decorator.rb
+++ b/app/decorators/models/spree/credit_card_decorator.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Spree
+  module CreditCardDecorator
+    def cc_type=(type)
+      # See https://stripe.com/docs/api/cards/object#card_object-brand,
+      # active_merchant/lib/active_merchant/billing/credit_card.rb,
+      # and active_merchant/lib/active_merchant/billing/credit_card_methods.rb
+      # (And see also the Solidus docs at core/app/models/spree/credit_card.rb,
+      # which indicate that Solidus uses ActiveMerchant conventions by default.)
+      self[:cc_type] = case type
+                       when 'American Express'
+                         'american_express'
+                       when 'Diners Club'
+                         'diners_club'
+                       when 'Discover'
+                         'discover'
+                       when 'JCB'
+                         'jcb'
+                       when 'MasterCard'
+                         'master'
+                       when 'UnionPay'
+                         'unionpay'
+                       when 'Visa'
+                         'visa'
+                       when 'Unknown'
+                         super('')
+                       else
+                         super(type)
+                       end
+    end
+
+    ::Spree::CreditCard.prepend(self)
+  end
+end

--- a/solidus_stripe.gemspec
+++ b/solidus_stripe.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'solidus_core', ['>= 2.3', '< 3']
   spec.add_dependency 'solidus_support', '~> 0.5'
   spec.add_dependency 'activemerchant', '>= 1.100'
+  spec.add_dependency 'stripe'
 
   spec.add_development_dependency 'solidus_dev_support'
 end

--- a/spec/features/stripe_checkout_spec.rb
+++ b/spec/features/stripe_checkout_spec.rb
@@ -124,31 +124,31 @@ RSpec.describe "Stripe checkout", type: :feature do
     end
 
     it "shows an error with a missing credit card number", js: true do
-      fill_in_card({ number: "", code: "" })
+      fill_in_card(number: "", code: "")
       click_button "Save and Continue"
       expect(page).to have_content("Could not find payment information")
     end
 
     it "shows an error with a missing expiration date", js: true do
-      fill_in_card({ exp_month: "", exp_year: "" })
+      fill_in_card(exp_month: "", exp_year: "")
       click_button "Save and Continue"
       expect(page).to have_content("Your card's expiration year is invalid.")
     end
 
     it "shows an error with an invalid credit card number", js: true do
-      fill_in_card({ number: "1111 1111 1111 1111" })
+      fill_in_card(number: "1111 1111 1111 1111")
       click_button "Save and Continue"
       expect(page).to have_content("Your card number is incorrect.")
     end
 
     it "shows an error with invalid security fields", js: true do
-      fill_in_card({ code: "12" })
+      fill_in_card(code: "12")
       click_button "Save and Continue"
       expect(page).to have_content("Your card's security code is invalid.")
     end
 
     it "shows an error with invalid expiry fields", js: true do
-      fill_in_card({ exp_month: "00" })
+      fill_in_card(exp_month: "00")
       click_button "Save and Continue"
       expect(page).to have_content("Your card's expiration month is invalid.")
     end
@@ -156,31 +156,31 @@ RSpec.describe "Stripe checkout", type: :feature do
 
   shared_examples "Stripe Elements invalid payments" do
     it "shows an error with a missing credit card number" do
-      fill_in_card({ number: "" })
+      fill_in_card(number: "")
       click_button "Save and Continue"
       expect(page).to have_content("Your card number is incomplete.")
     end
 
     it "shows an error with a missing expiration date" do
-      fill_in_card({ exp_month: "", exp_year: "" })
+      fill_in_card(exp_month: "", exp_year: "")
       click_button "Save and Continue"
       expect(page).to have_content("Your card's expiration date is incomplete.")
     end
 
     it "shows an error with an invalid credit card number" do
-      fill_in_card({ number: "1111 1111 1111 1111" })
+      fill_in_card(number: "1111 1111 1111 1111")
       click_button "Save and Continue"
       expect(page).to have_content("Your card number is invalid.")
     end
 
     it "shows an error with invalid security fields" do
-      fill_in_card({ code: "12" })
+      fill_in_card(code: "12")
       click_button "Save and Continue"
       expect(page).to have_content("Your card's security code is incomplete.")
     end
 
     it "shows an error with invalid expiry fields" do
-      fill_in_card({ exp_month: "01", exp_year: "3" })
+      fill_in_card(exp_month: "01", exp_year: "3")
       click_button "Save and Continue"
       expect(page).to have_content("Your card's expiration date is incomplete.")
     end
@@ -308,7 +308,7 @@ RSpec.describe "Stripe checkout", type: :feature do
 
     context "when using a card without enough money" do
       it "fails the payment" do
-        fill_in_card({ number: "4000 0000 0000 9995" })
+        fill_in_card(number: "4000 0000 0000 9995")
         click_button "Save and Continue"
 
         expect(page).to have_content "Your card has insufficient funds."
@@ -317,7 +317,7 @@ RSpec.describe "Stripe checkout", type: :feature do
 
     context "when entering the wrong 3D verification code" do
       it "fails the payment" do
-        fill_in_card({ number: "4000 0084 0000 1629" })
+        fill_in_card(number: "4000 0084 0000 1629")
         click_button "Save and Continue"
 
         within_3d_secure_modal do
@@ -414,7 +414,7 @@ RSpec.describe "Stripe checkout", type: :feature do
         let(:regular_card) { "4242 4242 4242 4242" }
 
         it "voids the first stripe payment and successfully pays with 3DS card" do
-          fill_in_card({ number: regular_card })
+          fill_in_card(number: regular_card)
           click_button "Save and Continue"
 
           expect(page).to have_content "Ending in #{regular_card.last(4)}"
@@ -481,7 +481,7 @@ RSpec.describe "Stripe checkout", type: :feature do
   end
 
   def authenticate_3d_secure_card(card_number)
-    fill_in_card({ number: card_number })
+    fill_in_card(number: card_number)
     click_button "Save and Continue"
 
     within_3d_secure_modal do

--- a/spec/features/stripe_customer_spec.rb
+++ b/spec/features/stripe_customer_spec.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'stripe'
+Stripe.api_key = "sk_test_VCZnDv3GLU15TRvn8i2EsaAN"
+
+RSpec.describe "Stripe checkout", type: :feature do
+  let(:zone) { FactoryBot.create(:zone) }
+  let(:country) { FactoryBot.create(:country) }
+
+  before do
+    FactoryBot.create(:store)
+    zone.members << Spree::ZoneMember.create!(zoneable: country)
+    FactoryBot.create(:free_shipping_method)
+
+    Spree::PaymentMethod::StripeCreditCard.create!(
+      name: "Stripe",
+      preferred_secret_key: "sk_test_VCZnDv3GLU15TRvn8i2EsaAN",
+      preferred_publishable_key: "pk_test_Cuf0PNtiAkkMpTVC2gwYDMIg",
+      preferred_v3_elements: preferred_v3_elements,
+      preferred_v3_intents: preferred_v3_intents
+    )
+
+    FactoryBot.create(:product, name: "DL-44")
+
+    visit spree.root_path
+    click_link "DL-44"
+    click_button "Add To Cart"
+
+    expect(page).to have_current_path("/cart")
+    click_button "Checkout"
+
+    expect(page).to have_current_path("/checkout/registration")
+    click_link "Create a new account"
+    within("#new_spree_user") do
+      fill_in "Email", with: "mary@example.com"
+      fill_in "Password", with: "superStrongPassword"
+      fill_in "Password Confirmation", with: "superStrongPassword"
+    end
+    click_button "Create"
+
+    # Address
+    expect(page).to have_current_path("/checkout/address")
+
+    within("#billing") do
+      fill_in_name
+      fill_in "Street Address", with: "YT-1300"
+      fill_in "City", with: "Mos Eisley"
+      select "United States of America", from: "Country"
+      select country.states.first.name, from: "order_bill_address_attributes_state_id"
+      fill_in "Zip", with: "12010"
+      fill_in "Phone", with: "(555) 555-5555"
+    end
+    click_on "Save and Continue"
+
+    # Delivery
+    expect(page).to have_current_path("/checkout/delivery")
+    expect(page).to have_content("UPS Ground")
+    click_on "Save and Continue"
+
+    # Payment
+    expect(page).to have_current_path("/checkout/payment")
+    fill_in_card
+    click_button "Save and Continue"
+
+    # Confirmation
+    expect(page).to have_current_path("/checkout/confirm")
+    click_button "Place Order"
+    expect(page).to have_content("Your order has been processed successfully")
+
+    # Begin Second Purchase
+    visit spree.root_path
+    click_link "DL-44"
+    click_button "Add To Cart"
+
+    expect(page).to have_current_path("/cart")
+    click_button "Checkout"
+
+    # Address
+    expect(page).to have_current_path("/checkout/address")
+
+    within("#billing") do
+      fill_in_name
+      fill_in "Street Address", with: "YT-1300"
+      fill_in "City", with: "Mos Eisley"
+      select "United States of America", from: "Country"
+      select country.states.first.name, from: "order_bill_address_attributes_state_id"
+      fill_in "Zip", with: "12010"
+      fill_in "Phone", with: "(555) 555-5555"
+    end
+    click_on "Save and Continue"
+
+    # Delivery
+    expect(page).to have_current_path("/checkout/delivery")
+    expect(page).to have_content("UPS Ground")
+    click_on "Save and Continue"
+
+    # Payment
+    expect(page).to have_current_path("/checkout/payment")
+  end
+
+  shared_examples "Maintain Consistent Stripe Customer Across Purchases" do
+    it "can re-use saved cards and maintain the same Stripe payment ID and customer ID", js: true do
+      choose "Use an existing card on file"
+      click_button "Save and Continue"
+
+      # Confirm
+      expect(page).to have_current_path("/checkout/confirm")
+      click_button "Place Order"
+      expect(page).to have_content("Your order has been processed successfully")
+
+      user = Spree::User.find_by(email: "mary@example.com")
+      user_sources = user.wallet.wallet_payment_sources
+      expect(user_sources.size).to eq(1)
+
+      user_card = user_sources.first.payment_source
+      expect(user_card.gateway_customer_profile_id).to start_with 'cus_'
+      expect(user_card.gateway_payment_profile_id).to start_with (preferred_v3_intents ? 'pm_' : 'card_')
+
+      stripe_customer = Stripe::Customer.retrieve(user_card.gateway_customer_profile_id)
+      expect(stripe_customer[:email]).to eq(user.email)
+      stripe_customer_cards = Stripe::PaymentMethod.list(customer: stripe_customer, type: 'card')
+      expect(stripe_customer_cards.count).to eq(1)
+      expect(stripe_customer_cards.first.customer).to eq(user_card.gateway_customer_profile_id)
+      expect(stripe_customer_cards.first.id).to eq(user_card.gateway_payment_profile_id)
+
+      expect(user.orders.map { |o| o.payments.valid.first.source.gateway_payment_profile_id }.uniq.size).to eq(1)
+      expect(user.orders.map { |o| o.payments.valid.first.source.gateway_customer_profile_id }.uniq.size).to eq(1)
+    end
+
+    it "can use a new card and maintain the same Stripe customer ID", js: true do
+      choose "Use a new card / payment method"
+      fill_in_card(number: '5555 5555 5555 4444')
+      click_button "Save and Continue"
+
+      # Confirm
+      expect(page).to have_current_path("/checkout/confirm")
+
+      user = Spree::User.find_by(email: "mary@example.com")
+      user_cards = user.credit_cards
+      expect(user_cards.size).to eq(2)
+      expect(user_cards.pluck(:gateway_customer_profile_id)).to all( start_with 'cus_' )
+      expect(user_cards.pluck(:gateway_payment_profile_id)).to all( start_with (preferred_v3_intents ? 'pm_' : 'card_'))
+      expect(user_cards.last.gateway_customer_profile_id).to eq(user_cards.first.gateway_customer_profile_id)
+      expect(user_cards.pluck(:gateway_customer_profile_id).uniq.size).to eq(1)
+
+      click_button "Place Order"
+      expect(page).to have_content("Your order has been processed successfully")
+
+      expect(user.wallet.wallet_payment_sources.size).to eq(2)
+      expect(user.orders.map { |o| o.payments.valid.first.source.gateway_payment_profile_id }.uniq.size).to eq(2)
+      expect(user.orders.map { |o| o.payments.valid.first.source.gateway_customer_profile_id }.uniq.size).to eq(1)
+
+      stripe_customer = Stripe::Customer.retrieve(user_cards.last.gateway_customer_profile_id)
+      stripe_customer_cards = Stripe::PaymentMethod.list(customer: stripe_customer, type: 'card')
+      expect(stripe_customer_cards.count).to eq(2)
+      expect(stripe_customer_cards.data.map(&:id)).to match_array(user.orders.map { |o| o.payments.valid.first.source.gateway_payment_profile_id }.uniq)
+      expect(stripe_customer_cards.data.map(&:id)).to match_array(user_cards.pluck(:gateway_payment_profile_id))
+    end
+  end
+
+  context 'when using Stripe V2 API library' do
+    let(:preferred_v3_elements) { false }
+    let(:preferred_v3_intents) { false }
+
+    it_behaves_like "Maintain Consistent Stripe Customer Across Purchases"
+  end
+
+  context 'when using Stripe V3 API library with Elements' do
+    let(:preferred_v3_elements) { true }
+    let(:preferred_v3_intents) { false }
+
+    it_behaves_like "Maintain Consistent Stripe Customer Across Purchases"
+  end
+
+  context 'when using Stripe V3 API library with Intents' do
+    let(:preferred_v3_elements) { false }
+    let(:preferred_v3_intents) { true }
+
+    it_behaves_like "Maintain Consistent Stripe Customer Across Purchases"
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,10 @@ require 'solidus_stripe/factories'
 # Requires card input helper defined in lib/solidus_stripe/testing_support/card_input_helper.rb
 require 'solidus_stripe/testing_support/card_input_helper'
 
+# Stripe config
+require 'stripe'
+Stripe.api_key = 'sk_test_VCZnDv3GLU15TRvn8i2EsaAN'
+
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   FactoryBot.find_definitions


### PR DESCRIPTION
This PR is a replacement / extension for the work in #77. It can commit cleanly if #77  is merged, or alternately #77 can be closed and this PR can take its place.

Changes from #77:

- Now [includes (passing) tests for maintaining stable Stripe customer profiles across purchases when using V3 Intents](https://github.com/solidusio/solidus_stripe/blob/a7d01ca16eb2fb918ac64d1e4b3afec7660c509e/spec/features/stripe_customer_spec.rb#L176-L181)! 🎉  In my view, that makes this a complete solution to #26.
- Uses the official Stripe gem rather than ActiveMerchant for the `create_profile` method, a stepping stone to the long-term goal of #74.

I’m very pleased with this result.

@spaghetticode Your code review of #77 was amazing, and I incorporated all of your suggestions there into this PR as well. What do you think?