### PR TITLE
Fix payment_intent_unexpected_state error when voiding payment intents

### DIFF
--- a/app/decorators/models/spree/payment_decorator.rb
+++ b/app/decorators/models/spree/payment_decorator.rb
@@ -6,6 +6,18 @@ module Spree
       gateway_order_id
     end
 
+    def handle_void_response(response)
+      record_response(response)
+
+      if response.success? ||
+         (response.params['error'] && response.params['error']['code'] == 'payment_intent_unexpected_state')
+        self.response_code = response.authorization
+        void
+      else
+        gateway_error(response)
+      end
+    end
+
     ::Spree::Payment.prepend(self)
   end
 end

--- a/spec/models/solidus_stripe/create_intents_payment_service_spec.rb
+++ b/spec/models/solidus_stripe/create_intents_payment_service_spec.rb
@@ -115,6 +115,18 @@ RSpec.describe SolidusStripe::CreateIntentsPaymentService do
         it "invalidates it" do
           expect { subject }.to change { payment.reload.state }.to 'void'
         end
+
+        context "and the response returns a payment_intent_unexpected_state error" do
+          before do
+            response_params = { 'error' => { 'code' => 'payment_intent_unexpected_state' } }
+            response = double(success?: false, authorization: payment.response_code, params: response_params)
+            expect_any_instance_of(Spree::PaymentMethod::StripeCreditCard).to receive(:void) { response }
+          end
+
+          it "invalidates it" do
+            expect { subject }.to change { payment.reload.state }.to 'void'
+          end
+        end
       end
 
       context "when none is a Payment Intent" do


### PR DESCRIPTION
Solves #64

If a payment intent has been created but the order is never completed, Stripe will eventually time out the intent and change its state. When a new payment intent is created, it first tries to void all the previous uncompleted payment intents of the user and this would break with the Stripe error payment_intent_unexpected_state since Stripe's state machine does not allow that change.